### PR TITLE
[Fix] 물품대여 시 상태 변경 안되는 버그 수정 && 로그인 시 유저 역할 반환

### DIFF
--- a/src/main/java/ssurent/ssurentbe/common/auth/dto/response/TokenResponse.java
+++ b/src/main/java/ssurent/ssurentbe/common/auth/dto/response/TokenResponse.java
@@ -1,11 +1,14 @@
 package ssurent.ssurentbe.common.auth.dto.response;
 
+import ssurent.ssurentbe.domain.users.enums.Role;
+
 public record TokenResponse(
         String accessToken,
         String refreshToken,
-        String tokenType
+        String tokenType,
+        Role role
 ) {
-    public static TokenResponse of(String accessToken, String refreshToken) {
-        return new TokenResponse(accessToken, refreshToken, "Bearer");
+    public static TokenResponse of(String accessToken, String refreshToken, Role role) {
+        return new TokenResponse(accessToken, refreshToken, "Bearer", role);
     }
 }

--- a/src/main/java/ssurent/ssurentbe/common/auth/service/AuthService.java
+++ b/src/main/java/ssurent/ssurentbe/common/auth/service/AuthService.java
@@ -45,7 +45,7 @@ public class AuthService {
         String accessToken = jwtTokenProvider.createAccessToken(user.getStudentNum());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getStudentNum());
 
-        return TokenResponse.of(accessToken, refreshToken);
+        return TokenResponse.of(accessToken, refreshToken, user.getRole());
     }
 
     public TokenResponse login(LoginRequest request) {
@@ -63,7 +63,7 @@ public class AuthService {
         String accessToken = jwtTokenProvider.createAccessToken(user.getStudentNum());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getStudentNum());
 
-        return TokenResponse.of(accessToken, refreshToken);
+        return TokenResponse.of(accessToken, refreshToken, user.getRole());
     }
 
     public TokenResponse refresh(String refreshToken) {
@@ -83,6 +83,6 @@ public class AuthService {
         String newAccessToken = jwtTokenProvider.createAccessToken(studentNum);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(studentNum);
 
-        return TokenResponse.of(newAccessToken, newRefreshToken);
+        return TokenResponse.of(newAccessToken, newRefreshToken, user.getRole());
     }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/item/entity/Items.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/entity/Items.java
@@ -50,6 +50,10 @@ public class Items extends BaseEntity {
         this.status = status;
     }
 
+    public void updateCondition(Condition condition) {
+        this.condition = condition;
+    }
+
     public void softDelete() {
         this.deleted = true;
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/ssurent/ssurentbe/domain/rental/repository/RentalRepository.java
+++ b/src/main/java/ssurent/ssurentbe/domain/rental/repository/RentalRepository.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 public interface RentalRepository extends JpaRepository<RentalHistory, Long> {
 
+    boolean existsByItemId_IdAndStatus(Long itemId, Status status);
+
     @Query("SELECT rh FROM RentalHistory rh " +
             "JOIN FETCH rh.itemId i " +
             "WHERE rh.userId.id = :userId " +

--- a/src/main/java/ssurent/ssurentbe/domain/rental/service/RentalCommandService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/rental/service/RentalCommandService.java
@@ -8,12 +8,14 @@ import ssurent.ssurentbe.common.status.ErrorStatus;
 import ssurent.ssurentbe.domain.assists.entity.Assists;
 import ssurent.ssurentbe.domain.assists.repository.AssistsRepository;
 import ssurent.ssurentbe.domain.item.entity.Items;
+import ssurent.ssurentbe.domain.item.enums.Condition;
 import ssurent.ssurentbe.domain.item.enums.Status;
 import ssurent.ssurentbe.domain.item.repository.ItemRepository;
 import ssurent.ssurentbe.domain.rental.dto.request.RentalRequest;
 import ssurent.ssurentbe.domain.rental.dto.response.RentalItemResponse;
 import ssurent.ssurentbe.domain.rental.entity.RentalHistory;
 import ssurent.ssurentbe.domain.rental.repository.RentalRepository;
+import static ssurent.ssurentbe.domain.rental.enums.Status.RENT;
 import ssurent.ssurentbe.domain.users.entity.Users;
 import ssurent.ssurentbe.domain.users.repository.UserRepository;
 
@@ -42,6 +44,10 @@ public class RentalCommandService {
             throw new GeneralException(ErrorStatus.ITEM_NOT_AVAILABLE);
         }
 
+        if (rentalRepository.existsByItemId_IdAndStatus(item.getId(), RENT)) {
+            throw new GeneralException(ErrorStatus.ITEM_NOT_AVAILABLE);
+        }
+
         Assists assist = assistsRepository.findByNameAndDeletedFalse(request.assistName())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ASSIST_NOT_FOUND));
 
@@ -49,6 +55,7 @@ public class RentalCommandService {
 
         rentalRepository.save(rentalHistory);
         item.updateStatus(Status.INACTIVE);
+        item.updateCondition(Condition.RENT);
 
         return RentalItemResponse.from(rentalHistory);
     }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #26  //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Issue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🧩 작업 내용
물품 대여 시 item의 condition이 keep에서 rent로 변경되도록 서비스 로직 추가
물품 중복 대여 방지를 위해 rentalhistory에서 rent상태가 있는 경우 대여 불가능하게 필터 추가

로그인 시 유저 역할 반환

## 📸 스크린샷(선택)
<img width="1069" height="177" alt="image" src="https://github.com/user-attachments/assets/26979da4-8917-4d92-b268-1d5da045e47d" />

<img width="601" height="422" alt="image" src="https://github.com/user-attachments/assets/b102e0a2-64ae-4d6b-95e6-13d0523f9a7f" />

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **새로운 기능**
  * 인증 토큰에 사용자 역할 정보가 포함되어 권한 관리 강화
  * 아이템 대여 중 상태와 조건을 추적할 수 있도록 개선

* **개선 사항**
  * 이미 대여 중인 아이템에 대한 중복 대여 요청을 사전에 차단

<!-- end of auto-generated comment: release notes by coderabbit.ai -->