### PR TITLE
[Feat] #29 대여사업 도우미 CRD

### DIFF
--- a/src/main/java/ssurent/ssurentbe/domain/assists/controller/admin/AssistAdminController.java
+++ b/src/main/java/ssurent/ssurentbe/domain/assists/controller/admin/AssistAdminController.java
@@ -3,8 +3,6 @@ package ssurent.ssurentbe.domain.assists.controller.admin;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import ssurent.ssurentbe.common.base.BaseResponse;
 import ssurent.ssurentbe.common.status.SuccessStatus;
@@ -25,8 +23,7 @@ public class AssistAdminController implements AssistAdminApiDocs {
 
     @GetMapping
     @Override
-    public ResponseEntity<BaseResponse<?>> getAssists(
-            @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<BaseResponse<?>> getAssists() {
         List<AdminAssistResponse> assists =  assistQueryService.getAssists();
         return ResponseEntity.status(HttpStatus.OK)
                 .body(BaseResponse.success(SuccessStatus.COMM_SUCCESS_STATUS,assists));
@@ -44,7 +41,6 @@ public class AssistAdminController implements AssistAdminApiDocs {
     @DeleteMapping("/{assistId}")
     @Override
     public ResponseEntity<BaseResponse<?>> deleteAssists(
-            @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long assistId) {
         assistCommandService.deleteAssist(assistId);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/ssurent/ssurentbe/domain/assists/controller/admin/AssistAdminController.java
+++ b/src/main/java/ssurent/ssurentbe/domain/assists/controller/admin/AssistAdminController.java
@@ -1,0 +1,53 @@
+package ssurent.ssurentbe.domain.assists.controller.admin;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import ssurent.ssurentbe.common.base.BaseResponse;
+import ssurent.ssurentbe.common.status.SuccessStatus;
+import ssurent.ssurentbe.domain.assists.controller.docs.AssistAdminApiDocs;
+import ssurent.ssurentbe.domain.assists.dto.request.AdminAssistCreateRequest;
+import ssurent.ssurentbe.domain.assists.dto.response.AdminAssistResponse;
+import ssurent.ssurentbe.domain.assists.service.AssistCommandService;
+import ssurent.ssurentbe.domain.assists.service.AssistQueryService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("v1/admin/assists")
+@RequiredArgsConstructor
+public class AssistAdminController implements AssistAdminApiDocs {
+    private final AssistCommandService assistCommandService;
+    private final AssistQueryService assistQueryService;
+
+    @GetMapping
+    @Override
+    public ResponseEntity<BaseResponse<?>> getAssists(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        List<AdminAssistResponse> assists =  assistQueryService.getAssists();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.success(SuccessStatus.COMM_SUCCESS_STATUS,assists));
+    }
+
+    @PostMapping
+    @Override
+    public ResponseEntity<BaseResponse<?>> createAssists(
+            @RequestBody AdminAssistCreateRequest request) {
+        AdminAssistResponse response = assistCommandService.createAssists(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(BaseResponse.success(SuccessStatus.COMM_CREATE_STATUS,response));
+    }
+
+    @DeleteMapping("/{assistId}")
+    @Override
+    public ResponseEntity<BaseResponse<?>> deleteAssists(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long assistId) {
+        assistCommandService.deleteAssist(assistId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.success(SuccessStatus.COMM_SUCCESS_STATUS));
+    }
+}

--- a/src/main/java/ssurent/ssurentbe/domain/assists/controller/docs/AssistAdminApiDocs.java
+++ b/src/main/java/ssurent/ssurentbe/domain/assists/controller/docs/AssistAdminApiDocs.java
@@ -1,0 +1,59 @@
+package ssurent.ssurentbe.domain.assists.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import ssurent.ssurentbe.common.base.BaseResponse;
+import ssurent.ssurentbe.domain.assists.dto.request.AdminAssistCreateRequest;
+import ssurent.ssurentbe.domain.assists.dto.response.AdminAssistResponse;
+
+@Tag(name = "Assist", description = "대여사업 도우미 API")
+public interface AssistAdminApiDocs {
+    @Operation(summary = "대여사업 도우미 조회", description = "대여사업 도우미 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "대여사업 도우미 목록 조회 성공",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = AdminAssistResponse.class))
+                    )),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    ResponseEntity<BaseResponse<?>> getAssists(
+            UserDetails userDetails
+    );
+
+    @Operation(summary = "대여사업 도우미 생성", description = "대여사업 도우미를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "대여사업 도우미 생성 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = AdminAssistResponse.class)
+                    )),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    ResponseEntity<BaseResponse<?>> createAssists(
+            AdminAssistCreateRequest request
+    );
+
+    @Operation(summary = "대여사업 도우미 삭제", description = "대여사업 도우미를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "대여사업 도우미 삭제 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = AdminAssistResponse.class)
+                    )),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    ResponseEntity<BaseResponse<?>> deleteAssists(
+            UserDetails userDetails,
+            Long assistId
+    );
+
+
+}

--- a/src/main/java/ssurent/ssurentbe/domain/assists/controller/docs/AssistAdminApiDocs.java
+++ b/src/main/java/ssurent/ssurentbe/domain/assists/controller/docs/AssistAdminApiDocs.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UserDetails;
 import ssurent.ssurentbe.common.base.BaseResponse;
 import ssurent.ssurentbe.domain.assists.dto.request.AdminAssistCreateRequest;
 import ssurent.ssurentbe.domain.assists.dto.response.AdminAssistResponse;
@@ -25,7 +24,6 @@ public interface AssistAdminApiDocs {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     ResponseEntity<BaseResponse<?>> getAssists(
-            UserDetails userDetails
     );
 
     @Operation(summary = "대여사업 도우미 생성", description = "대여사업 도우미를 생성합니다.")
@@ -45,13 +43,12 @@ public interface AssistAdminApiDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "대여사업 도우미 삭제 성공",
                     content = @Content(
-                            schema = @Schema(implementation = AdminAssistResponse.class)
+                            schema = @Schema(implementation = BaseResponse.class)
                     )),
             @ApiResponse(responseCode = "401", description = "인증 실패",
                     content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     ResponseEntity<BaseResponse<?>> deleteAssists(
-            UserDetails userDetails,
             Long assistId
     );
 

--- a/src/main/java/ssurent/ssurentbe/domain/assists/dto/response/AdminAssistResponse.java
+++ b/src/main/java/ssurent/ssurentbe/domain/assists/dto/response/AdminAssistResponse.java
@@ -1,7 +1,12 @@
 package ssurent.ssurentbe.domain.assists.dto.response;
 
+import ssurent.ssurentbe.domain.assists.entity.Assists;
+
 public record AdminAssistResponse(
         Long assistId,
         String assistName
 ) {
+    public static AdminAssistResponse from(Assists assists){
+        return new AdminAssistResponse(assists.getId(), assists.getName());
+    }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/assists/entity/Assists.java
+++ b/src/main/java/ssurent/ssurentbe/domain/assists/entity/Assists.java
@@ -2,6 +2,7 @@ package ssurent.ssurentbe.domain.assists.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 import ssurent.ssurentbe.common.base.BaseEntity;
 
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "Assists")
+@SQLRestriction("is_deleted = false")
 public class Assists extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,5 +33,9 @@ public class Assists extends BaseEntity {
         this.deleted = true;
         this.deletedAt = LocalDateTime.now();
         this.name = null;
+    }
+
+    public void softDelete() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/assists/entity/Assists.java
+++ b/src/main/java/ssurent/ssurentbe/domain/assists/entity/Assists.java
@@ -37,5 +37,6 @@ public class Assists extends BaseEntity {
 
     public void softDelete() {
         this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/assists/service/AssistCommandService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/assists/service/AssistCommandService.java
@@ -1,0 +1,36 @@
+package ssurent.ssurentbe.domain.assists.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ssurent.ssurentbe.common.exception.GeneralException;
+import ssurent.ssurentbe.common.status.ErrorStatus;
+import ssurent.ssurentbe.domain.assists.dto.request.AdminAssistCreateRequest;
+import ssurent.ssurentbe.domain.assists.dto.response.AdminAssistResponse;
+import ssurent.ssurentbe.domain.assists.entity.Assists;
+import ssurent.ssurentbe.domain.assists.repository.AssistsRepository;
+import ssurent.ssurentbe.domain.item.dto.request.AdminCategoryCreateRequest;
+import ssurent.ssurentbe.domain.item.dto.response.CategoryResponse;
+import ssurent.ssurentbe.domain.item.entity.Category;
+
+@Service
+@RequiredArgsConstructor
+public class AssistCommandService {
+    private final AssistsRepository assistsRepository;
+
+    @Transactional
+    public AdminAssistResponse createAssists(AdminAssistCreateRequest request) {
+        Assists assist = Assists.builder()
+                .name(request.assistName())
+                .build();
+        return AdminAssistResponse.from(assistsRepository.save(assist));
+    }
+
+    @Transactional
+    public void deleteAssist(Long assistId) {
+        Assists assist = assistsRepository.findById(assistId)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.ASSIST_NOT_FOUND));
+
+        assist.softDelete();
+    }
+}

--- a/src/main/java/ssurent/ssurentbe/domain/assists/service/AssistCommandService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/assists/service/AssistCommandService.java
@@ -9,9 +9,6 @@ import ssurent.ssurentbe.domain.assists.dto.request.AdminAssistCreateRequest;
 import ssurent.ssurentbe.domain.assists.dto.response.AdminAssistResponse;
 import ssurent.ssurentbe.domain.assists.entity.Assists;
 import ssurent.ssurentbe.domain.assists.repository.AssistsRepository;
-import ssurent.ssurentbe.domain.item.dto.request.AdminCategoryCreateRequest;
-import ssurent.ssurentbe.domain.item.dto.response.CategoryResponse;
-import ssurent.ssurentbe.domain.item.entity.Category;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/ssurent/ssurentbe/domain/assists/service/AssistQueryService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/assists/service/AssistQueryService.java
@@ -1,0 +1,24 @@
+package ssurent.ssurentbe.domain.assists.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ssurent.ssurentbe.domain.assists.dto.response.AdminAssistResponse;
+import ssurent.ssurentbe.domain.assists.entity.Assists;
+import ssurent.ssurentbe.domain.assists.repository.AssistsRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AssistQueryService {
+    private final AssistsRepository assistsRepository;
+
+    @Transactional
+    public List<AdminAssistResponse> getAssists() {
+        List<Assists> assistList = assistsRepository.findAll();
+        return assistList.stream()
+                .map(AdminAssistResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/ssurent/ssurentbe/domain/item/controller/admin/CategoryAdminController.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/controller/admin/CategoryAdminController.java
@@ -3,8 +3,6 @@ package ssurent.ssurentbe.domain.item.controller.admin;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import ssurent.ssurentbe.common.base.BaseResponse;
 import ssurent.ssurentbe.common.status.SuccessStatus;
@@ -26,8 +24,7 @@ public class CategoryAdminController implements CategoryAdminApiDocs {
 
     @Override
     @GetMapping()
-    public ResponseEntity<BaseResponse<?>> getCategories(
-            @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<BaseResponse<?>> getCategories() {
         List<CategoryResponse> categories =  categoryQueryService.getCategories();
         return ResponseEntity.status(HttpStatus.OK)
                 .body(BaseResponse.success(SuccessStatus.COMM_SUCCESS_STATUS,categories));
@@ -36,7 +33,6 @@ public class CategoryAdminController implements CategoryAdminApiDocs {
     @Override
     @PostMapping()
     public ResponseEntity<BaseResponse<?>> createCategory(
-            @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody AdminCategoryCreateRequest request) {
         CategoryResponse response = categoryCommandService.createCategories(request);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -46,7 +42,6 @@ public class CategoryAdminController implements CategoryAdminApiDocs {
     @Override
     @DeleteMapping("/{categoryId}")
     public ResponseEntity<BaseResponse<?>> deleteCategory(
-            @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long categoryId) {
         categoryCommandService.deleteCategory(categoryId);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/ssurent/ssurentbe/domain/item/controller/admin/ItemAdminController.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/controller/admin/ItemAdminController.java
@@ -4,8 +4,6 @@ package ssurent.ssurentbe.domain.item.controller.admin;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import ssurent.ssurentbe.common.base.BaseResponse;
 import ssurent.ssurentbe.common.status.SuccessStatus;
@@ -18,7 +16,6 @@ import ssurent.ssurentbe.domain.item.dto.response.ItemResponse;
 import ssurent.ssurentbe.domain.item.service.ItemCommandService;
 import ssurent.ssurentbe.domain.item.service.ItemQueryService;
 
-import java.util.Collections;
 import java.util.List;
 
 @RestController
@@ -30,7 +27,6 @@ public class ItemAdminController implements ItemAdminApiDocs {
 
     @GetMapping()
     public ResponseEntity<BaseResponse<?>> getItems(
-            @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(required = false) Long categoryId) {
         if (categoryId != null) {
             // 카테고리별 조회
@@ -46,7 +42,6 @@ public class ItemAdminController implements ItemAdminApiDocs {
     @PatchMapping
     @Override
     public ResponseEntity<BaseResponse<?>> updateItem(
-            @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody AdminItemUpdateRequest request) {
         List<ItemResponse> responses = itemCommandService.updateItemsStatus(request);
         return ResponseEntity.status(HttpStatus.OK)
@@ -56,7 +51,6 @@ public class ItemAdminController implements ItemAdminApiDocs {
     @Override
     @PostMapping()
     public ResponseEntity<BaseResponse<?>> createItem(
-            @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody AdminItemCreateRequest request) {
         itemCommandService.createItem(request);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -66,7 +60,6 @@ public class ItemAdminController implements ItemAdminApiDocs {
     @Override
     @GetMapping("/search")
     public ResponseEntity<BaseResponse<?>> searchItem(
-            @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(required = false) String keyword) {
 
         if (keyword == null || keyword.trim().isEmpty()) {

--- a/src/main/java/ssurent/ssurentbe/domain/item/controller/api/CategoryController.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/controller/api/CategoryController.java
@@ -3,8 +3,6 @@ package ssurent.ssurentbe.domain.item.controller.api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,8 +24,7 @@ public class CategoryController implements CategoryApiDocs {
 
     @Override
     @GetMapping
-    public ResponseEntity<BaseResponse<?>> getCategories(
-            @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<BaseResponse<?>> getCategories() {
         List<CategoryResponse> categories =  categoryQueryService.getCategories();
         return ResponseEntity.status(HttpStatus.OK)
                 .body(BaseResponse.success(SuccessStatus.COMM_SUCCESS_STATUS,categories));

--- a/src/main/java/ssurent/ssurentbe/domain/item/controller/api/ItemController.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/controller/api/ItemController.java
@@ -3,8 +3,6 @@ package ssurent.ssurentbe.domain.item.controller.api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -13,7 +11,6 @@ import ssurent.ssurentbe.common.base.BaseResponse;
 import ssurent.ssurentbe.common.status.SuccessStatus;
 import ssurent.ssurentbe.domain.item.controller.docs.items.ItemApiDocs;
 import ssurent.ssurentbe.domain.item.dto.response.ItemResponse;
-import ssurent.ssurentbe.domain.item.service.ItemCommandService;
 import ssurent.ssurentbe.domain.item.service.ItemQueryService;
 
 import java.util.List;
@@ -27,7 +24,6 @@ public class ItemController implements ItemApiDocs {
     @GetMapping()
     @Override
     public ResponseEntity<BaseResponse<?>> getActiveItems(
-            @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam Long categoryId) {
         List<ItemResponse> items =  itemQueryService.getActiveItemsByCategory(categoryId);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/ssurent/ssurentbe/domain/item/controller/docs/categories/CategoryAdminApiDocs.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/controller/docs/categories/CategoryAdminApiDocs.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UserDetails;
 import ssurent.ssurentbe.common.base.BaseResponse;
 import ssurent.ssurentbe.domain.item.dto.request.AdminCategoryCreateRequest;
 import ssurent.ssurentbe.domain.item.dto.response.CategoryResponse;
@@ -26,7 +25,6 @@ public interface CategoryAdminApiDocs {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     ResponseEntity<BaseResponse<?>> getCategories(
-            UserDetails userDetails
     );
 
     @Operation(summary = "카테고리 추가", description = "카테고리를 추가합니다.")
@@ -42,7 +40,6 @@ public interface CategoryAdminApiDocs {
             )
     })
     ResponseEntity<BaseResponse<?>> createCategory(
-            UserDetails userDetails,
             AdminCategoryCreateRequest request
     );
 
@@ -59,7 +56,6 @@ public interface CategoryAdminApiDocs {
             )
     })
     ResponseEntity<BaseResponse<?>> deleteCategory(
-            UserDetails userDetails,
             Long categoryId
     );
 }

--- a/src/main/java/ssurent/ssurentbe/domain/item/controller/docs/categories/CategoryApiDocs.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/controller/docs/categories/CategoryApiDocs.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UserDetails;
 import ssurent.ssurentbe.common.base.BaseResponse;
 import ssurent.ssurentbe.domain.item.dto.response.CategoryResponse;
 
@@ -24,6 +23,5 @@ public interface CategoryApiDocs {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     ResponseEntity<BaseResponse<?>> getCategories(
-            UserDetails userDetails
     );
 }

--- a/src/main/java/ssurent/ssurentbe/domain/item/controller/docs/items/ItemAdminApiDocs.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/controller/docs/items/ItemAdminApiDocs.java
@@ -8,12 +8,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UserDetails;
 import ssurent.ssurentbe.common.base.BaseResponse;
 import ssurent.ssurentbe.domain.item.dto.request.AdminItemCreateRequest;
 import ssurent.ssurentbe.domain.item.dto.request.AdminItemUpdateRequest;
 import ssurent.ssurentbe.domain.item.dto.response.AdminItemNameSearchResponse;
-import ssurent.ssurentbe.domain.item.dto.response.AdminItemResponse;
 import ssurent.ssurentbe.domain.item.dto.response.ItemResponse;
 
 @Tag(name = "Item-Admin", description = "관리자 아이템 API")
@@ -28,7 +26,6 @@ public interface ItemAdminApiDocs {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     ResponseEntity<BaseResponse<?>> getItems(
-            UserDetails userDetails,
             Long categoryId);
 
     @Operation(summary = "물품 상태 수정", description = "물품의 Status(활성화,비활성화 여부)를 수정합니다.")
@@ -41,7 +38,6 @@ public interface ItemAdminApiDocs {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     ResponseEntity<BaseResponse<?>> updateItem(
-            UserDetails userDetails,
             AdminItemUpdateRequest request);
 
     @Operation(summary = "물품 생성", description = "물품을 생성합니다.")
@@ -51,7 +47,6 @@ public interface ItemAdminApiDocs {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     ResponseEntity<BaseResponse<?>> createItem(
-            UserDetails userDetails,
             AdminItemCreateRequest request);
 
     @Operation(summary = "물품 키워드 검색", description = "키워드 기반으로 물품을 검색합니다.")
@@ -64,7 +59,6 @@ public interface ItemAdminApiDocs {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     ResponseEntity<BaseResponse<?>> searchItem(
-            UserDetails userDetails,
             String keyword);
 
 }

--- a/src/main/java/ssurent/ssurentbe/domain/item/controller/docs/items/ItemApiDocs.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/controller/docs/items/ItemApiDocs.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UserDetails;
 import ssurent.ssurentbe.common.base.BaseResponse;
 import ssurent.ssurentbe.domain.item.dto.response.ItemResponse;
 
@@ -25,6 +24,5 @@ public interface ItemApiDocs
                     content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     ResponseEntity<BaseResponse<?>> getActiveItems(
-            UserDetails userDetails,
             Long categoryId);
 }

--- a/src/main/java/ssurent/ssurentbe/domain/item/dto/response/AdminItemNameSearchResponse.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/dto/response/AdminItemNameSearchResponse.java
@@ -1,5 +1,6 @@
 package ssurent.ssurentbe.domain.item.dto.response;
 
+import ssurent.ssurentbe.domain.item.entity.Category;
 import ssurent.ssurentbe.domain.item.entity.Items;
 
 public record AdminItemNameSearchResponse(
@@ -7,12 +8,9 @@ public record AdminItemNameSearchResponse(
         String itemName
 ) {
     public static AdminItemNameSearchResponse from(Items item){
-        String ItemName = item.getName() + "(" + item.getItemNum() + ")";
-
-
         return new AdminItemNameSearchResponse(
                 item.getId(),
-                ItemName
+                item.getItemName()
         );
     }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/item/dto/response/ItemResponse.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/dto/response/ItemResponse.java
@@ -1,5 +1,6 @@
 package ssurent.ssurentbe.domain.item.dto.response;
 
+import ssurent.ssurentbe.domain.item.entity.Category;
 import ssurent.ssurentbe.domain.item.entity.Items;
 import ssurent.ssurentbe.domain.item.enums.Condition;
 import ssurent.ssurentbe.domain.item.enums.Status;
@@ -12,11 +13,10 @@ public record ItemResponse(
         Condition condition
 ) {
     public static ItemResponse from(Items item) {
-        String ItemName = item.getName() + "(" + item.getItemNum() + ")";
         return new ItemResponse(
                 item.getId(),
-                item.getName(),
-                ItemName,
+                item.getItemName(),
+                item.getCategoryId().getDescription(),
                 item.getStatus(),
                 item.getCondition()
         );

--- a/src/main/java/ssurent/ssurentbe/domain/item/entity/Category.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/entity/Category.java
@@ -19,7 +19,7 @@ public class Category extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name")
+    @Column(name = "name",unique = true)
     private String name;
 
     @Builder.Default

--- a/src/main/java/ssurent/ssurentbe/domain/item/entity/Items.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/entity/Items.java
@@ -14,7 +14,13 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "items")
+@Table(name = "items",
+uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_items_category_item_num",
+                columnNames = {"category_id","item_num"}
+        )
+})
 public class Items extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ssurent/ssurentbe/domain/item/entity/Items.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/entity/Items.java
@@ -24,8 +24,8 @@ public class Items extends BaseEntity {
     @JoinColumn(name = "category_id")
     private Category categoryId;
 
-    @Column(name = "name", nullable = false)
-    private String name;
+    @Column(name="item_name", nullable = false)
+    private String itemName;
 
     @Column(name = "item_num", nullable = false)
     private String itemNum;

--- a/src/main/java/ssurent/ssurentbe/domain/item/repository/ItemRepository.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/repository/ItemRepository.java
@@ -28,7 +28,7 @@ public interface ItemRepository extends JpaRepository<Items,Long> {
     @Query("SELECT i FROM Items i WHERE i.id = :id")
     Optional<Items> findByIdWithLock(@Param("id") Long id);
 
-    List<Items> findByItemNameStartingWith(String keyword);
+    List<Items> findByItemNameStartingWithAndDeletedFalse(String keyword);
 
-    boolean existsByItemNumAndCategoryId(String itemNum, Category categoryId);
+    boolean existsByItemNumAndCategoryIdAndDeletedFalse(String itemNum, Category categoryId);
 }

--- a/src/main/java/ssurent/ssurentbe/domain/item/repository/ItemRepository.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/repository/ItemRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import ssurent.ssurentbe.domain.item.entity.Category;
 import ssurent.ssurentbe.domain.item.entity.Items;
 
 import java.util.List;
@@ -27,8 +28,7 @@ public interface ItemRepository extends JpaRepository<Items,Long> {
     @Query("SELECT i FROM Items i WHERE i.id = :id")
     Optional<Items> findByIdWithLock(@Param("id") Long id);
 
-    // Repository
-    boolean existsByItemNumAndName(String itemNum, String itemName);
+    List<Items> findByItemNameStartingWith(String keyword);
 
-    List<Items> findByNameStartingWith(String keyword);
+    boolean existsByItemNumAndCategoryId(String itemNum, Category categoryId);
 }

--- a/src/main/java/ssurent/ssurentbe/domain/item/service/ItemCommandService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/service/ItemCommandService.java
@@ -64,7 +64,7 @@ public class ItemCommandService {
         // itemNum -> categoryName 순서로 타게 하기(인덱스가 없다면 일단...)
         Category category = categoryRepository.findByName(request.categoryName())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CATEGORY_NOT_FOUND));
-        if(itemRepository.existsByItemNumAndCategoryId(request.itemNum(), category)){
+        if(itemRepository.existsByItemNumAndCategoryIdAndDeletedFalse(request.itemNum(), category)){
             throw new GeneralException(ErrorStatus.DUPLICATE_ITEM);
         }
 

--- a/src/main/java/ssurent/ssurentbe/domain/item/service/ItemCommandService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/service/ItemCommandService.java
@@ -16,6 +16,7 @@ import ssurent.ssurentbe.domain.item.repository.ItemRepository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 
@@ -61,16 +62,15 @@ public class ItemCommandService {
         // categoryName == 우산 AND itemNum == 101 인 애가 있는지 검사
         // index없다면 풀스캔, 둘중 cardinalty가 높은건 itemNum,
         // itemNum -> categoryName 순서로 타게 하기(인덱스가 없다면 일단...)
-        if(itemRepository.existsByItemNumAndName(request.itemNum(), request.categoryName())){
+        Category category = categoryRepository.findByName(request.categoryName())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CATEGORY_NOT_FOUND));
+        if(itemRepository.existsByItemNumAndCategoryId(request.itemNum(), category)){
             throw new GeneralException(ErrorStatus.DUPLICATE_ITEM);
         }
 
-        Category category = categoryRepository.findByName(request.categoryName())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.CATEGORY_NOT_FOUND));
-
         Items item = Items.builder()
-                .name(request.categoryName())
                 .itemNum(request.itemNum())
+                .itemName(category.getName()+"("+request.itemNum()+")")
                 .categoryId(category)
                 .build();
 

--- a/src/main/java/ssurent/ssurentbe/domain/item/service/ItemQueryService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/service/ItemQueryService.java
@@ -59,7 +59,7 @@ public class ItemQueryService {
     }
 
     public List<AdminItemNameSearchResponse> searchByName(String keyword) {
-        List<Items> items = itemRepository.findByNameStartingWith(keyword);
+        List<Items> items = itemRepository.findByItemNameStartingWith(keyword);
 
         return items.stream()
                 .map(AdminItemNameSearchResponse::from)

--- a/src/main/java/ssurent/ssurentbe/domain/item/service/ItemQueryService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/item/service/ItemQueryService.java
@@ -59,7 +59,7 @@ public class ItemQueryService {
     }
 
     public List<AdminItemNameSearchResponse> searchByName(String keyword) {
-        List<Items> items = itemRepository.findByItemNameStartingWith(keyword);
+        List<Items> items = itemRepository.findByItemNameStartingWithAndDeletedFalse(keyword);
 
         return items.stream()
                 .map(AdminItemNameSearchResponse::from)

--- a/src/main/java/ssurent/ssurentbe/domain/rental/dto/response/AdminUserRentalHistoryResponse.java
+++ b/src/main/java/ssurent/ssurentbe/domain/rental/dto/response/AdminUserRentalHistoryResponse.java
@@ -1,5 +1,6 @@
 package ssurent.ssurentbe.domain.rental.dto.response;
 
+import ssurent.ssurentbe.domain.item.entity.Category;
 import ssurent.ssurentbe.domain.item.entity.Items;
 import ssurent.ssurentbe.domain.rental.entity.RentalHistory;
 import ssurent.ssurentbe.domain.rental.enums.Status;
@@ -17,13 +18,12 @@ public record AdminUserRentalHistoryResponse(
 ) {
     public static AdminUserRentalHistoryResponse from(RentalHistory rentalHistory) {
         Items items = rentalHistory.getItemId();
-        String itemName = items.getName() + "(" + items.getItemNum() + ")";
         return new AdminUserRentalHistoryResponse(
                 rentalHistory.getId(),
                 rentalHistory.getRentalDate(),
                 rentalHistory.getDueDate(),
                 rentalHistory.getReturnDate(),
-                itemName,
+                items.getItemName(),
                 rentalHistory.getStatus(),
                 rentalHistory.isOverdue()
         );

--- a/src/main/java/ssurent/ssurentbe/domain/rental/dto/response/AdminUserRentalItemResponse.java
+++ b/src/main/java/ssurent/ssurentbe/domain/rental/dto/response/AdminUserRentalItemResponse.java
@@ -1,5 +1,6 @@
 package ssurent.ssurentbe.domain.rental.dto.response;
 
+import ssurent.ssurentbe.domain.item.entity.Category;
 import ssurent.ssurentbe.domain.item.entity.Items;
 import ssurent.ssurentbe.domain.rental.entity.RentalHistory;
 
@@ -13,12 +14,11 @@ public record AdminUserRentalItemResponse(
 ) {
     public static AdminUserRentalItemResponse from(RentalHistory rentalHistory) {
         Items items = rentalHistory.getItemId();
-        String itemName = items.getName() + "(" + items.getItemNum() + ")";
         return new AdminUserRentalItemResponse(
                 rentalHistory.getId(),
                 rentalHistory.getRentalDate(),
                 rentalHistory.getReturnDate(),
-                itemName
+                items.getItemName()
         );
     }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/rental/dto/response/RentalItemResponse.java
+++ b/src/main/java/ssurent/ssurentbe/domain/rental/dto/response/RentalItemResponse.java
@@ -1,5 +1,6 @@
 package ssurent.ssurentbe.domain.rental.dto.response;
 
+import ssurent.ssurentbe.domain.item.entity.Category;
 import ssurent.ssurentbe.domain.item.entity.Items;
 import ssurent.ssurentbe.domain.rental.entity.RentalHistory;
 
@@ -14,11 +15,10 @@ public record RentalItemResponse(
 ) {
     public static RentalItemResponse from(RentalHistory rentalHistory) {
         Items items = rentalHistory.getItemId();
-        String itemName = items.getName() + "(" + items.getItemNum() + ")";
         return new RentalItemResponse(
                 rentalHistory.getId(),
                 rentalHistory.getItemId().getId(),
-                itemName,
+                items.getItemName(),
                 rentalHistory.getDueDate(),
                 rentalHistory.isOverdue()
         );

--- a/src/main/java/ssurent/ssurentbe/domain/rental/repository/RentalRepository.java
+++ b/src/main/java/ssurent/ssurentbe/domain/rental/repository/RentalRepository.java
@@ -29,7 +29,7 @@ public interface RentalRepository extends JpaRepository<RentalHistory, Long> {
             "WHERE rh.userId.id = :userId " +
             "AND (:startDate IS NULL OR rh.rentalDate >= :startDate) " +
             "AND (:endDate IS NULL OR rh.rentalDate <= :endDate) " +
-            "AND (:itemName IS NULL OR i.name LIKE %:itemName%) " +
+            "AND (:itemName IS NULL OR i.itemName LIKE %:itemName%) " +
             "ORDER BY rh.rentalDate DESC")
     List<RentalHistory> findByUserIdAndFilters(
             @Param("userId") Long userId,

--- a/src/main/java/ssurent/ssurentbe/domain/users/dto/response/UserPenaltyResponse.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/dto/response/UserPenaltyResponse.java
@@ -18,7 +18,7 @@ public record UserPenaltyResponse(
                 log.getId(),
                 log.getPenaltyType(),
                 log.getItemsId() != null ? log.getItemsId().getId() : null,
-                log.getItemsId() != null ? log.getItemsId().getName() : null,
+                log.getItemsId() != null ? log.getItemsId().getCategoryId().getName() : null,
                 log.getRentalHistoryId() != null ? log.getRentalHistoryId().getId() : null,
                 log.getCreatedAt()
         );


### PR DESCRIPTION
그냥 CUD입니다.

## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #29  //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #29  -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 코드 리팩토링

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🧩 작업 내용

Item 엔티티와 Category 엔티티를 리팩토링했습니다.
또한 Category 내 Description 항목을 생성했습니다.
**추후 CategoryCreate 시 Description도 입력받아야 합니다**

기존
```
        Items items = rentalHistory.getItemId();
        String itemName = items.getName() + "(" + items.getItemNum() + ")";
```
와 같이 조합해서 사용

개편 후
```
        items.getItemName(),
```
처럼 dto에서 한번에 사용
분리 목적
1. Category 고유의 이름과 Description을 Category 내부로 이동했습니다.
2. Item의 Name에는 Category 고유 이름 + ItemNum 으로 유지하도록 구성했습니다.
3. 이를 통해 Category에서 바로 사용하도록 진행했습니다.
4. 또한 Category의 name은 Unique 키를 사용하도록 하여, 더 빠른 인덱스 탐색과 무결성을 보장했습니다.

## 📸 스크린샷(선택)


📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자용 보조 서비스(Assist) 관리 API 추가: 목록 조회, 생성(HTTP 201), 삭제 지원
  * OpenAPI/Swagger 문서 추가로 API 명세 자동 제공

* **개선**
  * 보조(Assists) 엔티티에 소프트 삭제 도입 (물리 삭제 대신 표시만 변경)

* **변경**
  * 일부 관리자·공개 컨트롤러의 엔드포인트에서 인증 사용자 파라미터 제거로 API 입력이 단순화됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 대상 어시스트(보조도구) 관리 기능 추가: 조회, 생성, 삭제 가능

* **버그 수정**
  * 카테고리 및 아이템 데이터 검증 강화로 중복 항목 방지
  * 아이템 검색 시 삭제된 항목 제외

* **개선사항**
  * 카테고리 이름 고유성 제약 조건 추가
  * 데이터 삭제 시 소프트 삭제 처리로 데이터 무결성 향상
  * 아이템 명칭 관리 시스템 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->