### PR TITLE
[Feat] 관리자 API 추가

### DIFF
--- a/src/main/java/ssurent/ssurentbe/common/status/ErrorStatus.java
+++ b/src/main/java/ssurent/ssurentbe/common/status/ErrorStatus.java
@@ -56,6 +56,11 @@ public enum ErrorStatus implements BaseStatus {
     ASSIST_NOT_FOUND(HttpStatus.NOT_FOUND, "ASSIST_404", "도우미를 찾을 수 없습니다."),
 
     /**
+     * Penalty
+     */
+    PENALTY_NOT_FOUND(HttpStatus.NOT_FOUND, "PENALTY_404", "징계 이력을 찾을 수 없습니다."),
+
+    /**
      * Rental
      */
     RENTAL_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "RENTAL_400", "시작일이 종료일보다 늦을 수 없습니다"),

--- a/src/main/java/ssurent/ssurentbe/common/status/ErrorStatus.java
+++ b/src/main/java/ssurent/ssurentbe/common/status/ErrorStatus.java
@@ -51,6 +51,11 @@ public enum ErrorStatus implements BaseStatus {
     ITEM_NOT_AVAILABLE(HttpStatus.CONFLICT, "ITEM_409", "이미 대여 중인 물품입니다."),
 
     /**
+     * Users
+     */
+    USER_UPSERT_FAILED(HttpStatus.BAD_REQUEST, "USER_400", "유저 일괄 업데이트에 실패했습니다."),
+
+    /**
      * Assists
      */
     ASSIST_NOT_FOUND(HttpStatus.NOT_FOUND, "ASSIST_404", "도우미를 찾을 수 없습니다."),

--- a/src/main/java/ssurent/ssurentbe/domain/users/controller/admin/AdminUserController.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/controller/admin/AdminUserController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import ssurent.ssurentbe.common.base.BaseResponse;
 import ssurent.ssurentbe.common.status.SuccessStatus;
 import ssurent.ssurentbe.domain.users.controller.docs.AdminUserApiDocs;
+import ssurent.ssurentbe.domain.users.dto.request.AdminBulkUserUpdateRequest;
 import ssurent.ssurentbe.domain.users.dto.request.AdminUserPenaltyCreateRequest;
 import ssurent.ssurentbe.domain.users.dto.request.AdminUserStatusUpdateRequest;
 import ssurent.ssurentbe.domain.users.dto.response.AdminUserDetailResponse;
@@ -62,5 +63,14 @@ public class AdminUserController implements AdminUserApiDocs {
             @PathVariable Long penaltyId) {
         userPenaltyCommandService.deletePenalty(penaltyId);
         return ResponseEntity.ok(BaseResponse.success(SuccessStatus.COMM_SUCCESS_STATUS));
+    }
+
+    @Override
+    @PostMapping("/renewing")
+    public ResponseEntity<BaseResponse<?>> bulkUpsertUsers(
+            @RequestBody List<AdminBulkUserUpdateRequest> requests) {
+        userPenaltyCommandService.bulkUpsertUsers(requests);
+        return ResponseEntity.ok(BaseResponse.success(SuccessStatus.COMM_SUCCESS_STATUS));
+
     }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/controller/admin/AdminUserController.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/controller/admin/AdminUserController.java
@@ -1,6 +1,8 @@
 package ssurent.ssurentbe.domain.users.controller.admin;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ssurent.ssurentbe.common.base.BaseResponse;
@@ -52,9 +54,9 @@ public class AdminUserController implements AdminUserApiDocs {
     @Override
     @PostMapping("/penalties")
     public ResponseEntity<BaseResponse<?>> createPenalty(
-            @RequestBody AdminUserPenaltyCreateRequest request) {
+            @Valid @RequestBody AdminUserPenaltyCreateRequest request) {
         userPenaltyCommandService.createPenalty(request);
-        return ResponseEntity.ok(BaseResponse.success(SuccessStatus.COMM_CREATE_STATUS));
+        return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.success(SuccessStatus.COMM_CREATE_STATUS));
     }
 
     @Override
@@ -68,8 +70,8 @@ public class AdminUserController implements AdminUserApiDocs {
     @Override
     @PostMapping("/renewing")
     public ResponseEntity<BaseResponse<?>> bulkUpsertUsers(
-            @RequestBody List<AdminBulkUserUpdateRequest> requests) {
-        userPenaltyCommandService.bulkUpsertUsers(requests);
+            @Valid @RequestBody List<AdminBulkUserUpdateRequest> requests) {
+        userCommandService.bulkUpsertUsers(requests);
         return ResponseEntity.ok(BaseResponse.success(SuccessStatus.COMM_SUCCESS_STATUS));
 
     }

--- a/src/main/java/ssurent/ssurentbe/domain/users/controller/admin/AdminUserController.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/controller/admin/AdminUserController.java
@@ -1,0 +1,66 @@
+package ssurent.ssurentbe.domain.users.controller.admin;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ssurent.ssurentbe.common.base.BaseResponse;
+import ssurent.ssurentbe.common.status.SuccessStatus;
+import ssurent.ssurentbe.domain.users.controller.docs.AdminUserApiDocs;
+import ssurent.ssurentbe.domain.users.dto.request.AdminUserPenaltyCreateRequest;
+import ssurent.ssurentbe.domain.users.dto.request.AdminUserStatusUpdateRequest;
+import ssurent.ssurentbe.domain.users.dto.response.AdminUserDetailResponse;
+import ssurent.ssurentbe.domain.users.dto.response.AdminUserResponse;
+import ssurent.ssurentbe.domain.users.service.UserCommandService;
+import ssurent.ssurentbe.domain.users.service.UserPenaltyCommandService;
+import ssurent.ssurentbe.domain.users.service.UserQueryService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("v1/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController implements AdminUserApiDocs {
+    private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
+    private final UserPenaltyCommandService userPenaltyCommandService;
+
+    @Override
+    @GetMapping()
+    public ResponseEntity<BaseResponse<List<AdminUserResponse>>> getUsersByStatus(
+            @RequestParam String status
+    ) {
+        List<AdminUserResponse> responses = userQueryService.getUsersByStatus(status);
+        return ResponseEntity.ok(BaseResponse.success(SuccessStatus.COMM_SUCCESS_STATUS, responses));
+    }
+
+    @Override
+    @GetMapping("/{userId}")
+    public ResponseEntity<BaseResponse<AdminUserDetailResponse>> getUserDetails(
+            @PathVariable Long userId) {
+        AdminUserDetailResponse response = userQueryService.getUserDetails(userId);
+        return ResponseEntity.ok(BaseResponse.success(SuccessStatus.COMM_SUCCESS_STATUS, response));
+    }
+
+    @Override
+    @PatchMapping("/status")
+    public ResponseEntity<BaseResponse<?>> changeStatus(@RequestBody AdminUserStatusUpdateRequest request) {
+        userCommandService.changeStatus(request);
+        return ResponseEntity.ok(BaseResponse.success(SuccessStatus.COMM_SUCCESS_STATUS));
+    }
+
+    @Override
+    @PostMapping("/penalties")
+    public ResponseEntity<BaseResponse<?>> createPenalty(
+            @RequestBody AdminUserPenaltyCreateRequest request) {
+        userPenaltyCommandService.createPenalty(request);
+        return ResponseEntity.ok(BaseResponse.success(SuccessStatus.COMM_CREATE_STATUS));
+    }
+
+    @Override
+    @DeleteMapping("/penalties/{penaltyId}")
+    public ResponseEntity<BaseResponse<?>> deletePenalty(
+            @PathVariable Long penaltyId) {
+        userPenaltyCommandService.deletePenalty(penaltyId);
+        return ResponseEntity.ok(BaseResponse.success(SuccessStatus.COMM_SUCCESS_STATUS));
+    }
+}

--- a/src/main/java/ssurent/ssurentbe/domain/users/controller/api/UserController.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/controller/api/UserController.java
@@ -1,4 +1,4 @@
-package ssurent.ssurentbe.domain.users.controller;
+package ssurent.ssurentbe.domain.users.controller.api;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/ssurent/ssurentbe/domain/users/controller/docs/AdminUserApiDocs.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/controller/docs/AdminUserApiDocs.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import ssurent.ssurentbe.common.base.BaseResponse;
+import ssurent.ssurentbe.domain.users.dto.request.AdminBulkUserUpdateRequest;
 import ssurent.ssurentbe.domain.users.dto.request.AdminUserPenaltyCreateRequest;
 import ssurent.ssurentbe.domain.users.dto.request.AdminUserStatusUpdateRequest;
 import ssurent.ssurentbe.domain.users.dto.response.AdminUserDetailResponse;
@@ -64,4 +65,13 @@ public interface AdminUserApiDocs {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     ResponseEntity<BaseResponse<?>> deletePenalty(Long penaltyId);
+
+    @Operation(summary = "일괄 사용자 최신화", description = "사용자 데이터를 일괄 최신화 합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "입력 성공",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    ResponseEntity<BaseResponse<?>> bulkUpsertUsers(List<AdminBulkUserUpdateRequest> requests);
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/controller/docs/AdminUserApiDocs.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/controller/docs/AdminUserApiDocs.java
@@ -1,0 +1,67 @@
+package ssurent.ssurentbe.domain.users.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import ssurent.ssurentbe.common.base.BaseResponse;
+import ssurent.ssurentbe.domain.users.dto.request.AdminUserPenaltyCreateRequest;
+import ssurent.ssurentbe.domain.users.dto.request.AdminUserStatusUpdateRequest;
+import ssurent.ssurentbe.domain.users.dto.response.AdminUserDetailResponse;
+import ssurent.ssurentbe.domain.users.dto.response.AdminUserResponse;
+
+import java.util.List;
+
+@Tag(name = "User-Admin", description = "관리자 유저 API")
+public interface AdminUserApiDocs {
+    @Operation(summary = "원하는 사용자 목록 조회", description = "관리자가 전체/정지/관리자안 사용자를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = AdminUserResponse.class))
+                    )),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    ResponseEntity<BaseResponse<List<AdminUserResponse>>> getUsersByStatus(String status);
+
+    @Operation(summary = "사용자 ID 기반 조회", description = "관리자가 PathVariable로 사용자 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = AdminUserDetailResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    ResponseEntity<BaseResponse<AdminUserDetailResponse>> getUserDetails(Long userId);
+
+    @Operation(summary = "사용자 상태 변경", description = "관리자가 사용자 상태를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    ResponseEntity<BaseResponse<?>> changeStatus(AdminUserStatusUpdateRequest request);
+
+    @Operation(summary = "사용자 징계 추가", description = "관리자가 사용자 징계를 추가합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "추가 성공",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    ResponseEntity<BaseResponse<?>> createPenalty(AdminUserPenaltyCreateRequest request);
+
+    @Operation(summary = "사용자 징계 삭제", description = "관리자가 사용자 징계를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    ResponseEntity<BaseResponse<?>> deletePenalty(Long penaltyId);
+}

--- a/src/main/java/ssurent/ssurentbe/domain/users/dto/request/AdminBulkUserUpdateRequest.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/dto/request/AdminBulkUserUpdateRequest.java
@@ -1,0 +1,11 @@
+package ssurent.ssurentbe.domain.users.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminBulkUserUpdateRequest(
+        @NotNull String studentNum,
+        @NotBlank String name,
+        String phoneNum
+) {
+}

--- a/src/main/java/ssurent/ssurentbe/domain/users/dto/request/AdminUserPenaltyCreateRequest.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/dto/request/AdminUserPenaltyCreateRequest.java
@@ -3,8 +3,9 @@ package ssurent.ssurentbe.domain.users.dto.request;
 
 import java.time.LocalDateTime;
 
-public record AdminUserPenaltyCreateRequest (
-        String itemName,
-        String penaltyType
-){
-}
+    public record AdminUserPenaltyCreateRequest (
+            Long userId,
+            String itemName,
+            String penaltyType
+    ){
+    }

--- a/src/main/java/ssurent/ssurentbe/domain/users/dto/request/AdminUserPenaltyCreateRequest.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/dto/request/AdminUserPenaltyCreateRequest.java
@@ -1,11 +1,14 @@
 package ssurent.ssurentbe.domain.users.dto.request;
 
 
+import jakarta.validation.constraints.Pattern;
+
 import java.time.LocalDateTime;
 
     public record AdminUserPenaltyCreateRequest (
             Long userId,
             String itemName,
+            @Pattern(regexp = "^(OVERDUE|UNAUTHORIZED_USE|OTHER)$", message = "유효하지 않은 패널티 타입입니다")
             String penaltyType
     ){
     }

--- a/src/main/java/ssurent/ssurentbe/domain/users/dto/request/AdminUserStatusUpdateRequest.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/dto/request/AdminUserStatusUpdateRequest.java
@@ -3,6 +3,7 @@ package ssurent.ssurentbe.domain.users.dto.request;
 import ssurent.ssurentbe.domain.users.enums.Status;
 
 public record AdminUserStatusUpdateRequest(
+        Long userId,
         Status status
 ) {
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/dto/response/AdminUserResponse.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/dto/response/AdminUserResponse.java
@@ -2,11 +2,13 @@ package ssurent.ssurentbe.domain.users.dto.response;
 
 import ssurent.ssurentbe.domain.users.entity.Users;
 import ssurent.ssurentbe.domain.users.enums.Role;
+import ssurent.ssurentbe.domain.users.enums.Status;
 
 public record AdminUserResponse(
     Long userId,
     String userName,
     String studentNum,
+    Status status,
     Role role
 ) {
     public static AdminUserResponse from(Users user) {
@@ -14,6 +16,7 @@ public record AdminUserResponse(
                 user.getId(),
                 user.getName(),
                 user.getStudentNum(),
+                user.getStatus(),
                 user.getRole()
         );
     }

--- a/src/main/java/ssurent/ssurentbe/domain/users/dto/response/UserPenaltyResponse.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/dto/response/UserPenaltyResponse.java
@@ -8,18 +8,14 @@ import java.time.LocalDateTime;
 public record UserPenaltyResponse(
         Long penaltyId,
         PenaltyTypes penaltyType,
-        Long itemId,
         String itemName,
-        Long rentalHistoryId,
         LocalDateTime createdAt
 ) {
     public static UserPenaltyResponse from(UserPenaltyLog log) {
         return new UserPenaltyResponse(
                 log.getId(),
                 log.getPenaltyType(),
-                log.getItemsId() != null ? log.getItemsId().getId() : null,
-                log.getItemsId() != null ? log.getItemsId().getCategoryId().getName() : null,
-                log.getRentalHistoryId() != null ? log.getRentalHistoryId().getId() : null,
+                log.getItemName(),
                 log.getCreatedAt()
         );
     }

--- a/src/main/java/ssurent/ssurentbe/domain/users/entity/UserPenaltyLog.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/entity/UserPenaltyLog.java
@@ -3,8 +3,6 @@ package ssurent.ssurentbe.domain.users.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import ssurent.ssurentbe.common.base.BaseEntity;
-import ssurent.ssurentbe.domain.item.entity.Items;
-import ssurent.ssurentbe.domain.rental.entity.RentalHistory;
 import ssurent.ssurentbe.domain.users.enums.PenaltyTypes;
 
 @Entity
@@ -12,7 +10,7 @@ import ssurent.ssurentbe.domain.users.enums.PenaltyTypes;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "user_panalty_log")
+@Table(name = "user_penalty_log")
 public class UserPenaltyLog extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,16 +20,10 @@ public class UserPenaltyLog extends BaseEntity {
     @JoinColumn(name = "user_id")
     private Users userId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "items_id")
-    private Items itemsId;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "history_id")
-    private RentalHistory rentalHistoryId;
+    @Column(name = "item_name")
+    private String itemName;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "panalty_type")
+    @Column(name = "penalty_type")
     private PenaltyTypes penaltyType;
-
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/entity/Users.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/entity/Users.java
@@ -52,6 +52,12 @@ public class Users extends BaseEntity{
         this.phoneNum = null;
         this.studentNum = null;
     }
+
+    //회원 복구
+    public void restore(){
+        this.deleted = false;
+    }
+
     public void updatePhoneNumber(String phoneNum) {
         this.phoneNum = phoneNum;
     }

--- a/src/main/java/ssurent/ssurentbe/domain/users/entity/Users.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/entity/Users.java
@@ -56,6 +56,7 @@ public class Users extends BaseEntity{
     //회원 복구
     public void restore(){
         this.deleted = false;
+        this.deletedAt = null;
     }
 
     public void updatePhoneNumber(String phoneNum) {

--- a/src/main/java/ssurent/ssurentbe/domain/users/entity/Users.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/entity/Users.java
@@ -56,4 +56,7 @@ public class Users extends BaseEntity{
         this.phoneNum = phoneNum;
     }
 
+    public void updateStatus(Status status){
+        this.status = status;
+    }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/entity/Users.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/entity/Users.java
@@ -59,4 +59,9 @@ public class Users extends BaseEntity{
     public void updateStatus(Status status){
         this.status = status;
     }
+
+    public void updateInfo(String name, String phoneNum){
+        this.name = name;
+        this.phoneNum = phoneNum;
+    }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/enums/PenaltyTypes.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/enums/PenaltyTypes.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum PenaltyTypes {
     OVERDUE("반납기한 경과"),
-    UNAUTHORIZED_USE("무단 사용");
+    UNAUTHORIZED_USE("무단 사용"),
+    OTHER("기타");
 
     private final String description;
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/repository/UserRepository.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/repository/UserRepository.java
@@ -3,7 +3,10 @@ package ssurent.ssurentbe.domain.users.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ssurent.ssurentbe.domain.users.entity.Users;
+import ssurent.ssurentbe.domain.users.enums.Role;
+import ssurent.ssurentbe.domain.users.enums.Status;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +14,8 @@ public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByStudentNum(String studentNum);
     boolean existsByStudentNum(String studentNum);
     Optional<Users> findByStudentNumAndDeletedFalse(String studentNum);
+    List<Users> findByDeletedFalse();
+    List<Users> findByStatusAndDeletedFalse(Status status);
+    List<Users> findByRoleInAndDeletedFalse(List<Role> roles);
+    Optional<Users> findByIdAndDeletedFalse(Long userId);
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/service/UserCommandService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/service/UserCommandService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ssurent.ssurentbe.common.exception.GeneralException;
 import ssurent.ssurentbe.common.status.ErrorStatus;
+import ssurent.ssurentbe.domain.users.dto.request.AdminUserStatusUpdateRequest;
 import ssurent.ssurentbe.domain.users.entity.Users;
 import ssurent.ssurentbe.domain.users.repository.UserRepository;
 
@@ -23,5 +24,12 @@ public class UserCommandService {
         Users user = getUserInfo(username);
 
         user.updatePhoneNumber(phoneNum);
+    }
+
+    @Transactional
+    public void changeStatus(AdminUserStatusUpdateRequest request) {
+        Users user = userRepository.findByIdAndDeletedFalse(request.userId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        user.updateStatus(request.status());
     }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/service/UserCommandService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/service/UserCommandService.java
@@ -1,19 +1,26 @@
 package ssurent.ssurentbe.domain.users.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ssurent.ssurentbe.common.exception.GeneralException;
 import ssurent.ssurentbe.common.status.ErrorStatus;
+import ssurent.ssurentbe.domain.users.dto.request.AdminBulkUserUpdateRequest;
 import ssurent.ssurentbe.domain.users.dto.request.AdminUserStatusUpdateRequest;
 import ssurent.ssurentbe.domain.users.entity.Users;
+import ssurent.ssurentbe.domain.users.enums.Role;
 import ssurent.ssurentbe.domain.users.repository.UserRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserCommandService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public Users getUserInfo(String username) {
         return userRepository.findByStudentNumAndDeletedFalse(username)
@@ -31,5 +38,38 @@ public class UserCommandService {
         Users user = userRepository.findByIdAndDeletedFalse(request.userId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         user.updateStatus(request.status());
+    }
+
+    @Transactional
+    public void bulkUpsertUsers(List<AdminBulkUserUpdateRequest> requests) {
+
+        try{
+            for (AdminBulkUserUpdateRequest req : requests) {
+                Optional<Users> existing = userRepository.findByStudentNumAndDeletedFalse(req.studentNum());
+
+                if (existing.isPresent()) {
+                    Users user = existing.get();
+                    user.updateInfo(req.name(), req.phoneNum());
+                    user.restore();
+                } else {
+                    Users user = Users.builder()
+                            .studentNum(req.studentNum())
+                            .name(req.name())
+                            .phoneNum(req.phoneNum())
+                            .password(passwordEncoder.encode(
+                                    req.phoneNum().isBlank()
+                                            ? req.studentNum()
+                                            : req.phoneNum())
+                            )
+                            .role(Role.NORMAL)
+                            .deleted(false)
+                            .build();
+                    userRepository.save(user);
+                }
+            }
+        }
+        catch (Exception e){
+            throw new GeneralException(ErrorStatus.USER_UPSERT_FAILED);
+        }
     }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/service/UserCommandService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/service/UserCommandService.java
@@ -10,6 +10,7 @@ import ssurent.ssurentbe.domain.users.dto.request.AdminBulkUserUpdateRequest;
 import ssurent.ssurentbe.domain.users.dto.request.AdminUserStatusUpdateRequest;
 import ssurent.ssurentbe.domain.users.entity.Users;
 import ssurent.ssurentbe.domain.users.enums.Role;
+import ssurent.ssurentbe.domain.users.enums.Status;
 import ssurent.ssurentbe.domain.users.repository.UserRepository;
 
 import java.util.List;
@@ -62,6 +63,7 @@ public class UserCommandService {
                                             : req.phoneNum())
                             )
                             .role(Role.NORMAL)
+                            .status(Status.ACTIVE)
                             .deleted(false)
                             .build();
                     userRepository.save(user);

--- a/src/main/java/ssurent/ssurentbe/domain/users/service/UserPenaltyCommandService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/service/UserPenaltyCommandService.java
@@ -1,0 +1,43 @@
+package ssurent.ssurentbe.domain.users.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ssurent.ssurentbe.common.exception.GeneralException;
+import ssurent.ssurentbe.common.status.ErrorStatus;
+import ssurent.ssurentbe.domain.users.dto.request.AdminUserPenaltyCreateRequest;
+import ssurent.ssurentbe.domain.users.entity.UserPenaltyLog;
+import ssurent.ssurentbe.domain.users.entity.Users;
+import ssurent.ssurentbe.domain.users.enums.PenaltyTypes;
+import ssurent.ssurentbe.domain.users.repository.UserPenaltyLogRepository;
+import ssurent.ssurentbe.domain.users.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UserPenaltyCommandService {
+    private final UserRepository userRepository;
+    private final UserPenaltyLogRepository userPenaltyLogRepository;
+
+    @Transactional
+    public void createPenalty(AdminUserPenaltyCreateRequest request) {
+        Users user = userRepository.findByIdAndDeletedFalse(request.userId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        PenaltyTypes penaltyType = PenaltyTypes.valueOf(request.penaltyType());
+
+        UserPenaltyLog penaltyLog = UserPenaltyLog.builder()
+                .userId(user)
+                .itemName(request.itemName())
+                .penaltyType(penaltyType)
+                .build();
+
+        userPenaltyLogRepository.save(penaltyLog);
+    }
+
+    @Transactional
+    public void deletePenalty(Long penaltyId) {
+        UserPenaltyLog userPenaltyLog = userPenaltyLogRepository.findById(penaltyId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PENALTY_NOT_FOUND));
+        userPenaltyLogRepository.delete(userPenaltyLog);
+    }
+}

--- a/src/main/java/ssurent/ssurentbe/domain/users/service/UserPenaltyCommandService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/service/UserPenaltyCommandService.java
@@ -45,36 +45,4 @@ public class UserPenaltyCommandService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PENALTY_NOT_FOUND));
         userPenaltyLogRepository.delete(userPenaltyLog);
     }
-
-    @Transactional
-    public void bulkUpsertUsers(List<AdminBulkUserUpdateRequest> requests) {
-
-        try{
-            for (AdminBulkUserUpdateRequest req : requests) {
-                Optional<Users> existing = userRepository.findByStudentNum(req.studentNum());
-
-                if (existing.isPresent()) {
-                    Users user = existing.get();
-                    user.updateInfo(req.name(), req.phoneNum());
-                } else {
-                    Users user = Users.builder()
-                            .studentNum(req.studentNum())
-                            .name(req.name())
-                            .phoneNum(req.phoneNum())
-                            .password(
-                                    req.phoneNum().isBlank()
-                                            ? req.studentNum()
-                                            : req.phoneNum()
-                            )
-                            .role(Role.NORMAL)
-                            .deleted(false)
-                            .build();
-                    userRepository.save(user);
-                }
-            }
-        }
-        catch (Exception e){
-            throw new GeneralException(ErrorStatus.USER_UPSERT_FAILED);
-        }
-    }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/service/UserPenaltyCommandService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/service/UserPenaltyCommandService.java
@@ -5,12 +5,17 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ssurent.ssurentbe.common.exception.GeneralException;
 import ssurent.ssurentbe.common.status.ErrorStatus;
+import ssurent.ssurentbe.domain.users.dto.request.AdminBulkUserUpdateRequest;
 import ssurent.ssurentbe.domain.users.dto.request.AdminUserPenaltyCreateRequest;
 import ssurent.ssurentbe.domain.users.entity.UserPenaltyLog;
 import ssurent.ssurentbe.domain.users.entity.Users;
 import ssurent.ssurentbe.domain.users.enums.PenaltyTypes;
+import ssurent.ssurentbe.domain.users.enums.Role;
 import ssurent.ssurentbe.domain.users.repository.UserPenaltyLogRepository;
 import ssurent.ssurentbe.domain.users.repository.UserRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -39,5 +44,32 @@ public class UserPenaltyCommandService {
         UserPenaltyLog userPenaltyLog = userPenaltyLogRepository.findById(penaltyId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PENALTY_NOT_FOUND));
         userPenaltyLogRepository.delete(userPenaltyLog);
+    }
+
+    @Transactional
+    public void bulkUpsertUsers(List<AdminBulkUserUpdateRequest> requests) {
+
+        for (AdminBulkUserUpdateRequest req : requests) {
+            Optional<Users> existing = userRepository.findByStudentNum(req.studentNum());
+
+            if (existing.isPresent()) {
+                Users user = existing.get();
+                user.updateInfo(req.name(), req.phoneNum());
+            } else {
+                Users user = Users.builder()
+                        .studentNum(req.studentNum())
+                        .name(req.name())
+                        .phoneNum(req.phoneNum())
+                        .password(
+                                req.phoneNum().isBlank()
+                                        ? req.studentNum()
+                                        : req.phoneNum()
+                        )
+                        .role(Role.NORMAL)
+                        .deleted(false)
+                        .build();
+                userRepository.save(user);
+            }
+        }
     }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/service/UserPenaltyCommandService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/service/UserPenaltyCommandService.java
@@ -49,27 +49,32 @@ public class UserPenaltyCommandService {
     @Transactional
     public void bulkUpsertUsers(List<AdminBulkUserUpdateRequest> requests) {
 
-        for (AdminBulkUserUpdateRequest req : requests) {
-            Optional<Users> existing = userRepository.findByStudentNum(req.studentNum());
+        try{
+            for (AdminBulkUserUpdateRequest req : requests) {
+                Optional<Users> existing = userRepository.findByStudentNum(req.studentNum());
 
-            if (existing.isPresent()) {
-                Users user = existing.get();
-                user.updateInfo(req.name(), req.phoneNum());
-            } else {
-                Users user = Users.builder()
-                        .studentNum(req.studentNum())
-                        .name(req.name())
-                        .phoneNum(req.phoneNum())
-                        .password(
-                                req.phoneNum().isBlank()
-                                        ? req.studentNum()
-                                        : req.phoneNum()
-                        )
-                        .role(Role.NORMAL)
-                        .deleted(false)
-                        .build();
-                userRepository.save(user);
+                if (existing.isPresent()) {
+                    Users user = existing.get();
+                    user.updateInfo(req.name(), req.phoneNum());
+                } else {
+                    Users user = Users.builder()
+                            .studentNum(req.studentNum())
+                            .name(req.name())
+                            .phoneNum(req.phoneNum())
+                            .password(
+                                    req.phoneNum().isBlank()
+                                            ? req.studentNum()
+                                            : req.phoneNum()
+                            )
+                            .role(Role.NORMAL)
+                            .deleted(false)
+                            .build();
+                    userRepository.save(user);
+                }
             }
+        }
+        catch (Exception e){
+            throw new GeneralException(ErrorStatus.USER_UPSERT_FAILED);
         }
     }
 }

--- a/src/main/java/ssurent/ssurentbe/domain/users/service/UserQueryService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/service/UserQueryService.java
@@ -58,7 +58,7 @@ public class UserQueryService {
     }
 
     public AdminUserDetailResponse getUserDetails(Long userId) {
-        Users user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        Users user = userRepository.findByIdAndDeletedFalse(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         List<UserPenaltyLog> logs = userPenaltyLogRepository.findByUserIdOrderByCreatedAtDesc(user);
 
         return AdminUserDetailResponse.from(user,logs);

--- a/src/main/java/ssurent/ssurentbe/domain/users/service/UserQueryService.java
+++ b/src/main/java/ssurent/ssurentbe/domain/users/service/UserQueryService.java
@@ -5,10 +5,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ssurent.ssurentbe.common.exception.GeneralException;
 import ssurent.ssurentbe.common.status.ErrorStatus;
+import ssurent.ssurentbe.domain.users.dto.response.AdminUserDetailResponse;
+import ssurent.ssurentbe.domain.users.dto.response.AdminUserResponse;
 import ssurent.ssurentbe.domain.users.dto.response.UserInfoResponse;
 import ssurent.ssurentbe.domain.users.dto.response.UserPenaltyResponse;
 import ssurent.ssurentbe.domain.users.entity.UserPenaltyLog;
 import ssurent.ssurentbe.domain.users.entity.Users;
+import ssurent.ssurentbe.domain.users.enums.Role;
+import ssurent.ssurentbe.domain.users.enums.Status;
 import ssurent.ssurentbe.domain.users.repository.UserPenaltyLogRepository;
 import ssurent.ssurentbe.domain.users.repository.UserRepository;
 
@@ -38,5 +42,25 @@ public class UserQueryService {
         return logs.stream()
                 .map(UserPenaltyResponse::from)
                 .collect(Collectors.toList());
+    }
+
+    public List<AdminUserResponse> getUsersByStatus(String status) {
+        List<Users> users = switch (status) {
+            case "전체회원" -> userRepository.findByDeletedFalse();
+            case "정지회원" -> userRepository.findByStatusAndDeletedFalse(Status.BANNED);
+            case "관리자"   -> userRepository.findByRoleInAndDeletedFalse(List.of(Role.ADMIN, Role.SUPERADMIN));
+            default -> throw new IllegalArgumentException("지원하지 않는 상태입니다: " + status);
+        };
+
+        return users.stream()
+                .map(AdminUserResponse::from)
+                .toList();
+    }
+
+    public AdminUserDetailResponse getUserDetails(Long userId) {
+        Users user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        List<UserPenaltyLog> logs = userPenaltyLogRepository.findByUserIdOrderByCreatedAtDesc(user);
+
+        return AdminUserDetailResponse.from(user,logs);
     }
 }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #37 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Issue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 파일 혹은 폴더명 수정

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🧩 작업 내용

- Penalty Entity를 변경했습니다.
- PenaltyTypes 에 OTHER 를 추가했습니다.
- 관리자용 User 조회 API를 구현했습니다.
- 관리자용 Penalty CD API를 구현했습니다.
- 관리자용 유저 일괄 갱신 API를 구현했습니다.

## 📸 스크린샷(선택)


📣 **To Reviewers**
---
<!-- 전달사항 -->

Penalty Entity의 변경으로, UserPenaltyResponse도 변경되었습니다.
Penalty Entity의 변경으로, MySQL Penalty Table도 변경되었습니다.

PenaltyType에 OTHER를 넣어서, 기존 외의 경우를 대비했습니다.

관리자용 유저 일괄 갱신 시
전화번호가 "" 면 학번이, 그 외의 경우 전화번호를 초기 PW로 저장합니다.

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 관리자용 사용자 관리 API/UI 추가: 상태별 목록, 상세 조회, 상태 변경, 징계 등록·삭제
  * 일괄 사용자 업서트(다중 업데이트/생성) 기능 및 입력 검증 강화
  * 징계 생성 요청에 사용자 지정 필드 및 패턴 검증 추가

* **Bug Fixes**
  * DB 스키마 명칭(테이블/컬럼) 및 징계 응답 매핑 오류 수정
  * 징계 유형에 '기타' 옵션 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->